### PR TITLE
Add Climb Angle Meter to board climbing resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Curating a list of useful climbing web/app resources
 
 [MapfortheBoard](https://akirosingh.github.io/mapfortheboard/) - A map of public boards across the world (Moon, Kilter, Tension, Grasshopper, Decoy, and Touchstone)
 
+[Climb Angle Meter (Android)](https://play.google.com/store/apps/details?id=com.climbangletool.climbangletool) - A purpose-built app for checking and adjusting the angle of system boards or other indoor walls. Android-only for now.
+
 ### Moonboard 🌕
 
 [BoardStalker](https://boardstalker.com/) - Moonboard leaderboards


### PR DESCRIPTION
A bit ago I made a simple app to measure the angle of system boards since all of the protractor apps are pretty fiddly, and there's a much better way for measuring the angle of a slope.

I thought it'd be worth adding here since I saw it on climbharder - but if it's too simple/not what you're looking for, totally fine.